### PR TITLE
Add support for python37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Rowan Molony <rowan.molony@codema.ie>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
 numpy = "^1.19.4"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Jupyter Notebook docker build used by mybinder defaults
to Python 3.7 so failed as seai_drem only supports > 3.8